### PR TITLE
handle POST requests + pass options to signalR hub connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     }
     window.console.debug = logger;
   },
-  hubConnection: (serverUrl, headers) => {
+  hubConnection: (serverUrl, options) => {
     if (!signalRHubConenctionFunc) {
       require('ms-signalr-client');
       signalRHubConenctionFunc = window.jQuery.hubConnection;
@@ -40,8 +40,10 @@ module.exports = {
       }
     };
 
-    window.jQuery.defaultAjaxHeaders = headers;
+    if (options && options.headers) {
+      window.jQuery.defaultAjaxHeaders = options.headers;
+    }
 
-    return signalRHubConenctionFunc(serverUrl);
+    return signalRHubConenctionFunc(serverUrl, options);
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 let signalRHubConnectionFunc;
 let oldLogger = window.console.debug;
-window.document = {
-  readyState: 'complete'
-};
+
 if (!window.addEventListener) {
   window.addEventListener = window.addEventListener = () => {};
 }
@@ -21,6 +19,9 @@ module.exports = {
     window.console.debug = logger;
   },
   hubConnection: (serverUrl, options) => {
+    window.document = window.document || {
+      readyState: 'complete'
+    };
     if (!signalRHubConnectionFunc) {
       require('ms-signalr-client');
       signalRHubConnectionFunc = window.jQuery.hubConnection;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-let signalRHubConenctionFunc;
+let signalRHubConnectionFunc;
 let oldLogger = window.console.debug;
 window.document = {
   readyState: 'complete'
@@ -21,9 +21,9 @@ module.exports = {
     window.console.debug = logger;
   },
   hubConnection: (serverUrl, options) => {
-    if (!signalRHubConenctionFunc) {
+    if (!signalRHubConnectionFunc) {
       require('ms-signalr-client');
-      signalRHubConenctionFunc = window.jQuery.hubConnection;
+      signalRHubConnectionFunc = window.jQuery.hubConnection;
     }
     const protocol = serverUrl.split('//')[0];
     const host = serverUrl.split('//')[1];
@@ -44,6 +44,6 @@ module.exports = {
       window.jQuery.defaultAjaxHeaders = options.headers;
     }
 
-    return signalRHubConenctionFunc(serverUrl, options);
+    return signalRHubConnectionFunc(serverUrl, options);
   }
 };

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -12,9 +12,9 @@ export default function(options, data) {
     }
   };
 
-  request.setRequestHeader('content-type', options.contentType);
-  
   request.open(options.type, options.url);
+  request.setRequestHeader('content-type', options.contentType);
+
   request.send(options.data.data && `data=${options.data.data}`);
   
   return {

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -12,9 +12,11 @@ export default function(options, data) {
     }
   };
 
-  request.open('GET', options.url);
-  request.send();
-
+  request.setRequestHeader('content-type', options.contentType);
+  
+  request.open(options.type, options.url);
+  request.send(options.data.data && `data=${options.data.data}`);
+  
   return {
     abort: function(reason) {
       return request.abort(reason);


### PR DESCRIPTION
- In order to invoke a server method, the ajax shim has to support POST requests. 
- In order to override hubConnection defaults (e.g. useDefaultPath) , the react native hubConnection should pass the options to $.hubConnection