### PR TITLE
Fix connecting to a websocket the second time returning "window.document is undefined"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export default {
     const hubConnectionFunc = signalRHubConnectionFunc(serverUrl, options);
     const originalStart = hubConnectionFunc.start;
     hubConnectionFunc.start = (...args) => {
+      window.document = window.document || { readyState: 'complete' };
       window.document.createElement = () => {
         return {
           protocol,


### PR DESCRIPTION


window.document is setup the first time, then cleared after start() is called... we need to reset up the window.document each time start() is called