### PR TITLE
Fix post data for AJAX polyfill

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,3 +1,10 @@
+const qs = (data) => {
+    let results = [];
+    for (const name in data)
+        results.push(`${name}=${encodeURIComponent(data[name])}`);
+    return results.join("&");
+}
+
 export default (options) => {
   const request = new XMLHttpRequest();
   request.onreadystatechange = () => {
@@ -15,7 +22,7 @@ export default (options) => {
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);
 
-  request.send(options.data.data && `data=${options.data.data}`);
+  request.send(options.data && qs(options.data));
 
   return {
     abort: (reason) => {


### PR DESCRIPTION
I am not sure the reason; however, the AJAX polyfill was only pushing through the `data` parameter in the POST data if present.  In my case, with long polling, this was leaving out `messageId` which seems to be fundamental in making long polling work.

This PR uses a lightweight URL parameter encoding to push the entire POST data.

This rectified the long polling functionality in my use case.  I have not tested and am not aware of the following:

1. This may or may not fix other instances where other POST data is relied upon for correct SignalR operation.
2. Any regression that this my cause.  I do find it peculiar that only the `data` parameter explicitly was being passed through so do have some concerns that this was for a valid reason.